### PR TITLE
Windows build with Appveyor setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+image: Visual Studio 2017
+
+environment:
+  PYTHON: C:\Python36-x64
+
+install:
+  - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%;C:\Program Files (x86)\NSIS\Bin
+  - python -m pip install --disable-pip-version-check --upgrade pip
+  - pip install -r windows-requirements.txt
+  - pip install --upgrade pynsist
+
+build_script:
+  - python build-nsis.py
+
+artifacts:
+  - path: .\build\nsis\RemarkableAssistant*.exe
+
+test: off

--- a/build-nsis.py
+++ b/build-nsis.py
@@ -1,0 +1,28 @@
+import os
+import shutil
+import subprocess
+import sys
+
+
+# Pre-build wheels. These need to be in sync with installer.cfg. Not the
+# best way to do it, but let's not do things too fancy until we need them.
+WHEEL_NEEDED = [
+    'Kivy-Garden==0.1.4',
+    'pycparser==2.18',
+]
+wheels_dir = os.path.join(os.path.dirname(__file__), 'build', 'wheels')
+os.makedirs(wheels_dir, exist_ok=True)
+for req in WHEEL_NEEDED:
+    subprocess.check_call(
+        [sys.executable, '-m', 'pip', 'wheel', req],
+        cwd=wheels_dir,
+    )
+
+
+# Copy needed DLLs.
+share_target = os.path.join(os.path.dirname(__file__), 'build', 'share')
+if not os.path.isdir(share_target):
+    shutil.copytree(os.path.join(sys.prefix, 'share'), share_target)
+
+# Run pynsist to build the installer.
+subprocess.check_call([sys.executable, '-m', 'nsist', 'installer.cfg'])

--- a/installer.cfg
+++ b/installer.cfg
@@ -1,0 +1,42 @@
+[Application]
+name = RemarkableAssistant
+version = 0
+script = run.py
+console = true
+
+[Python]
+version = 3.6.4
+
+[Include]
+pypi_wheels =
+    asn1crypto==0.24.0
+    certifi==2018.1.18
+    cffi==1.11.4
+    chardet==3.0.4
+    cryptography==2.1.4
+    Cython==0.26.1
+    Django==2.0.2
+    docutils==0.14
+    idna==2.6
+    image==1.5.17
+    Kivy==1.10.0
+    Kivy-Garden==0.1.4
+    kivy.deps.glew==0.1.9
+    kivy.deps.sdl2==0.1.17
+    paramiko==2.1.2
+    Pillow==5.0.0
+    pyasn1==0.4.2
+    pycparser==2.18
+    Pygments==2.2.0
+    pypiwin32==220
+    pytz==2017.3
+    requests==2.18.4
+    six==1.11.0
+    urllib3==1.22
+
+extra_wheel_sources = build\wheels
+
+files = src\main.py
+    src\additional-templates
+    src\static
+    build\share > $INSTDIR\Python

--- a/run.py
+++ b/run.py
@@ -1,0 +1,12 @@
+#!python3.6
+
+import os
+import sys
+
+ROOT = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(ROOT, 'pkgs'))
+sys.path.append(ROOT)
+
+if __name__ == '__main__':
+    import main
+    main.MyApp().run()


### PR DESCRIPTION
Adds a few support files to build the app with pynsist, and configuration for Appveyor to automate the builds. You’ll need to setup your own Appveyor project (it’s pretty easy; simply register, create a new project from the GitHub repo, and push a commit with appveyor.yml).

The build will [look like this](https://ci.appveyor.com/project/uranusjr/remarkable-assistant). You can find the built installer in the *Artifacts* tab.

There seems to be a few errors when I launch the application. I don’t have the Remarkable hardware so I can’t do much further testing, but those seems to be relatively easy to fix (I think).

I only built for 64-bit; you can add more variants (e.g. 32-bit) yourself with proper configuration. See Appveyor config and pynsist documentation for more information.