### PR TITLE
Modified Readme and Requirements to get it to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once the above is verified, run the following commands:
 
 `C:\Python27\python.exe -m pip install --upgrade pip`
 
-`C:\Python27\pythone.exe -m pip install -r windows-requirements.txt`
+`C:\Python27\python.exe -m pip install -r windows-requirements.txt`
 
 Run the application:
 
@@ -42,7 +42,7 @@ Run the application:
 
 # How to use it
 1. Plug your remarkable tablet into your computer via USB
-2. Set the password the remarkable ssh password you see under rM->About
+2. Set the password to the remarkable ssh password you see under rM->About
 3. Click the 'Reconnect' button so the assistant will pull down your config
 4. Remarkable Assistant should fill in the missing fields with the current values
 5. You can now change the new password and timeout fields

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Cython==0.26.1
-Kivy>=1.10.0
+Kivy==1.11.0
 Kivy-Garden==0.1.4
 paramiko==2.1.2
 pathlib==1.0.1


### PR DESCRIPTION
Modified Readme to resolve typos

Modified Requirements to pin Kivy to version 1.11.0, as it was trying to pull Kivy 2.0, which is unsupported in Python 2.7